### PR TITLE
Updates for RHEL images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 * A kubernetes version of 1.8 or higher
 * For service broker - a k8s distribution that supports service catalog (see also: https://kubernetes.io/docs/concepts/extend-kubernetes/service-catalog/) 
 
+#### Note: For Ubuntu/Alpine images for deployments outside OpenShift, please update the image tags in redis-enterprise-cluster.yaml and operator.yaml by either dropping .rhel from the tag or using another non .rhel tag
+
 #### Deployment:
 
 Clone this repository, which contains the deployment files:
@@ -96,7 +98,7 @@ A typical response may look like this:
 ```
 
 Create A Redis Enterprise Cluster:
-Choose the configuration relevant for you - you may find additional examples in the examples folder.
+Choose the configuration relevant for you - you may find additional examples in the examples folder. Note that you will need to add the image tag if you'd like to pull a RHEL image.
 
 ```kubectl apply -f redis-enterprise-cluster.yaml```
 

--- a/operator.yaml
+++ b/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccount: redis-enterprise-operator
       containers:
         - name: redis-enterprise-operator
-          image: redislabs/operator:134_d537d44
+          image: redislabs/operator:266_441f1a1.rhel7
           command:
           - redis-enterprise-operator
           imagePullPolicy: Always

--- a/redis-enterprise-cluster.yaml
+++ b/redis-enterprise-cluster.yaml
@@ -19,5 +19,5 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     Repository:       redislabs/redis
-    versionTag:       5.2.0-14
+    versionTag:       100.0.0-1098.rhel7-openshift.alpha
 

--- a/redis-enterprise-cluster.yaml
+++ b/redis-enterprise-cluster.yaml
@@ -19,5 +19,5 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     Repository:       redislabs/redis
-    versionTag:       100.0.0-1098.rhel7-openshift.alpha
+    versionTag:       5.2.2-22.rhel7-openshift
 


### PR DESCRIPTION
Changed operator.yaml and redis-enterprise-cluster.yaml to point to .rhel tags. May still need to update the RS tag if a new image is pushed.
Updated readme.md to alert non OpenShift users to changes they need to make for Ubuntu/Alpine images. Updated the readme to reflect changes OpenShift users need to make to samples to pull RHEL images.