### PR TITLE
Updated cluster image tag to latest

### DIFF
--- a/redis-enterprise-cluster_rhel.yaml
+++ b/redis-enterprise-cluster_rhel.yaml
@@ -19,7 +19,7 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     Repository:       redislabs/redis
-    versionTag:       5.2.2-22.rhel7-openshift
+    versionTag:       5.4.0-19.rhel7-openshift
   redisEnterpriseControllerImageSpec:
     imagePullPolicy:  IfNotPresent
     Repository:       redislabs/k8s-controller


### PR DESCRIPTION
The latest cluster image tag is 5.4.0-19.rhel7-openshift