### PR TITLE
Updated RHEL SB example to latest cluster tag

### DIFF
--- a/examples/with_service_broker_rhel.yaml
+++ b/examples/with_service_broker_rhel.yaml
@@ -18,7 +18,7 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.2.2-22.rhel7-openshift
+    versionTag:       5.4.0-19.rhel7-openshift 
   redisEnterpriseControllerImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/k8s-controller


### PR DESCRIPTION
The latest cluster tag is 5.4.0-19.rhel7-openshift