### PR TITLE
RED-32947 Redis Enterprise version should be 5.4.6-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The following are the images and tags for this release:
 
 Redis Enterprise    -   `redislabs/redis:5.4.6-18` or `redislabs/redis:5.4.6-18.rhel7-openshift`
 
-Operator            -   `redislabs/operator:5.4.6-1086` or `redislabs/operator:5.4.6-1086.rhel7`
+Operator            -   `redislabs/operator:5.4.6-1182` or `redislabs/operator:5.4.6-1182.rhel7`
 
-Services Rigger     -   `redislabs/k8s-controller:5.4.6-1086` or `redislabs/k8s-controller:5.4.6-1086.rhel7`
+Services Rigger     -   `redislabs/k8s-controller:5.4.6-1182` or `redislabs/k8s-controller:5.4.6-1182.rhel7`
 
 Service Broker      -   `redislabs/service-broker:78_4b9b17f` or `redislabs/service-broker:78_4b9b17f.rhel7`
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For Service Broker, please see examples/with_service_broker_rhel.yaml. RedHat ce
 
 The following are the images and tags for this release:
 
-Redis Enterprise    -   `redislabs/redis:5.4.6-17` or `redislabs/redis:5.4.6-17.rhel7-openshift`
+Redis Enterprise    -   `redislabs/redis:5.4.6-18` or `redislabs/redis:5.4.6-18.rhel7-openshift`
 
 Operator            -   `redislabs/operator:5.4.6-1086` or `redislabs/operator:5.4.6-1086.rhel7`
 
@@ -154,7 +154,7 @@ Redis Image
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.6-17
+    versionTag:       5.4.6-18
 ```
 
 Persistence

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ For Service Broker, please see examples/with_service_broker_rhel.yaml. RedHat ce
 
 The following are the images and tags for this release:
 
-Redis Enterprise -  	redislabs/redis:5.4.6-17 / 5.4.6-17.rhel7-openshift
+Redis Enterprise    -   `redislabs/redis:5.4.6-17` or `redislabs/redis:5.4.6-17.rhel7-openshift`
 
-Operator -  	 redislabs/operator:5.4.6-1086 / 5.4.6-1086.rhel7
+Operator            -   `redislabs/operator:5.4.6-1086` or `redislabs/operator:5.4.6-1086.rhel7`
 
-Services Rigger - 	redislabs/k8s-controller:5.4.6-1086 / 5.4.6-1086.rhel7
+Services Rigger     -   `redislabs/k8s-controller:5.4.6-1086` or `redislabs/k8s-controller:5.4.6-1086.rhel7`
 
-Service Broker - 	redislabs/service-broker:78_4b9b17f / 78_4b9b17f.rhel7
+Service Broker      -   `redislabs/service-broker:78_4b9b17f` or `redislabs/service-broker:78_4b9b17f.rhel7`
 
 
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Redis Image
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.2-27
+    versionTag:       5.4.6-17
 ```
 
 Persistence

--- a/examples/with_service_broker_rhel.yaml
+++ b/examples/with_service_broker_rhel.yaml
@@ -11,4 +11,4 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.6-17.rhel7-openshift
+    versionTag:       5.4.6-18.rhel7-openshift

--- a/examples/with_service_broker_rhel.yaml
+++ b/examples/with_service_broker_rhel.yaml
@@ -11,5 +11,4 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.2-27.rhel7-openshift
-
+    versionTag:       5.4.6-17.rhel7-openshift

--- a/operator.yaml
+++ b/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccount: redis-enterprise-operator
       containers:
         - name: redis-enterprise-operator
-          image: redislabs/operator:5.4.6-1086
+          image: redislabs/operator:5.4.6-1182
           securityContext:
             runAsUser: 1001
           command:

--- a/operator_rhel.yaml
+++ b/operator_rhel.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccount: redis-enterprise-operator
       containers:
         - name: redis-enterprise-operator
-          image: redislabs/operator:5.4.6-1086.rhel7
+          image: redislabs/operator:5.4.6-1182.rhel7
           securityContext:
             runAsUser: 1001
           command:

--- a/redis-enterprise-cluster_rhel.yaml
+++ b/redis-enterprise-cluster_rhel.yaml
@@ -19,5 +19,5 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.6-17.rhel7-openshift
+    versionTag:       5.4.6-18.rhel7-openshift
 

--- a/redis-enterprise-cluster_rhel.yaml
+++ b/redis-enterprise-cluster_rhel.yaml
@@ -19,5 +19,5 @@ spec:
   redisEnterpriseImageSpec:
     imagePullPolicy:  IfNotPresent
     repository:       redislabs/redis
-    versionTag:       5.4.2-27.rhel7-openshift
+    versionTag:       5.4.6-17.rhel7-openshift
 


### PR DESCRIPTION
Operator version is 5.4.6-1182 - part of RS v5.4.6-18 release. 
Same for the services rigger.