### PR TITLE
Collecting the logs for all containers inside each redis enterprise pod

### DIFF
--- a/log_collector.py
+++ b/log_collector.py
@@ -159,7 +159,7 @@ def collect_pods_logs(namespace, output_dir):
         return
 
     for pod in pods:
-        cmd = "kubectl logs -n {} {}".format(namespace, pod)
+        cmd = "kubectl logs -n {} {} --all-containers=true".format(namespace, pod)
         with open(os.path.join(logs_dir, "{}.log".format(pod)), "w+") as fp:
             p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             while True:


### PR DESCRIPTION
There are now several containers in each redis enterprise pod (redis-enterprise-node and bootstrapper) so we either need to specify each container name, or gather logs for all the containers.