### PR TITLE
correction of default username

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Redis Enterprise Nodes (pods)
 
 User Name to be used for accessing the cluster. Default is demo@redislabs.com
 ```yaml
-username: "admin@acme.com"
+username: "demo@redislabs.com"
 ```
 
 UI service type: Load Balancer or cluster IP (default)


### PR DESCRIPTION
The default username in the yaml should be demo@redislabs.com instead of admin@acme.com