### PR TITLE
replace: "size:" with "nodes:"

### DIFF
--- a/docs/topics.md
+++ b/docs/topics.md
@@ -67,7 +67,7 @@ kind: RedisEnterpriseCluster
 metadata:
   name: example-redisenterprisecluster
 spec:
-  size: 3
+  nodes: 3
   nodeSelector:
     cloud.google.com/gke-nodepool: pool1
 ```


### PR DESCRIPTION
I think "size:" is an artifact of the auto-generated file but we use "nodes:" instead.