### PR TITLE
Updating the verification steps

### DIFF
--- a/admission/GESHER.md
+++ b/admission/GESHER.md
@@ -239,12 +239,14 @@ $ kubectl apply -f - << EOF
 apiVersion: app.redislabs.com/v1alpha1
 kind: RedisEnterpriseDatabase
 metadata:
-  name: test-database-custom-resource
+  name: redis-enterprise-database
+spec:
+  evictionPolicy: illegal
 EOF
 ```
 
-This must fail with an error output by the admission webhook redb.admisison.redislabs that is being denied because it can't get the login credentials for the Redis Enterprise Cluster as none were specified.
+This must fail with an error output by the admission webhook proxy.webhook.gesher that is being denied because 'illegal' is not a valid eviction policy.
 
 ```shell script
-Error from server: error when creating "STDIN": admission webhook "proxy.webhook.gesher" denied the request: proxied webhook webhook denied the request: failed get RedisEnterpriseCluster client: custom resource (RedisEnterpriseCluster) not found: resource name may not be empty
+Error from server: error when creating "adm_redb.yaml": admission webhook "proxy.webhook.gesher" denied the request: proxied webhook webhook denied the request: eviction_policy: u'illegal' is not one of [u'volatile-lru', u'volatile-ttl', u'volatile-random', u'allkeys-lru', u'allkeys-random', u'noeviction', u'volatile-lfu', u'allkeys-lfu']
 ```


### PR DESCRIPTION
The update was done for the regular admission controller, but not for Gesher. It is now OK to have a REDB that has no REC name.