### PR TITLE
This PR adds additionalPrinterColumns to "kubectl get redb"

### DIFF
--- a/crds/v1alpha1/redb_crd.yaml
+++ b/crds/v1alpha1/redb_crd.yaml
@@ -3,6 +3,28 @@ kind: CustomResourceDefinition
 metadata:
   name: redisenterprisedatabases.app.redislabs.com
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.internalEndpoints[*].host
+      name: Host
+      type: string
+    - JSONPath: .status.internalEndpoints[*].port
+      name: Port
+      type: string
+    - JSONPath: .status.redisEnterpriseCluster
+      name: Cluster
+      type: string
+    - JSONPath: .status.shardStatuses.active
+      name: Shards
+      type: string
+    - JSONPath: .status.status
+      name: Status
+      type: string
+    - JSONPath: .status.specStatus
+      name: Spec Status
+      type: string
+    - JSONPath: .status.createdTime
+      name: Age
+      type: date
   group: app.redislabs.com
   names:
     kind: RedisEnterpriseDatabase


### PR DESCRIPTION
This PR adds additionalPrinterColumns to "kubectl get redb" to show useful spec status, particularly HOST:PORT, CLUSTER and SHARDS. It's specially usef

This is the output generated:
    
``` 
$ kubectl -n redis-kweb get redb
NAME                HOST                                                     PORT    CLUSTER         SHARDS   STATUS   SPEC STATUS   AGE
redis-db-caches     redis-12484.redis-cluster.redis-kweb.svc.cluster.local   12484   redis-cluster   1        active   Valid         6d22h
redis-db-sessions   redis-13649.redis-cluster.redis-kweb.svc.cluster.local   13649   redis-cluster   1        active   Valid         6d23h

```