### PR TITLE
Removed reference to a file that doesn't exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ The operator deploys a `RedisEnterpriseCluster` with default configurations valu
 
 Whenever images are not pulled from DockerHub, the following configuration must be specified:
 
-In *RedisEnterpriseClusterSpec* (redis_enterprise_cluster.yaml):
+In *RedisEnterpriseClusterSpec* :
 - *redisEnterpriseImageSpec*
 - *redisEnterpriseServicesRiggerImageSpec*
 - *bootstrapperImageSpec*


### PR DESCRIPTION
Plus there is really no need to refer to a file here. You modify whatever holds your REC definition.