### PR TITLE
The fsGroup specification is incorrect

### DIFF
--- a/openshift/scc.yaml
+++ b/openshift/scc.yaml
@@ -8,8 +8,10 @@ allowedCapabilities:
 runAsUser:
   type: MustRunAs
   uid: 1001
-FSGroup:
+fsGroup:
   type: MustRunAs
-  ranges: 1001,1001
+  ranges:
+  - min: 1001
+    max: 1001
 seLinuxContext:
   type: RunAsAny


### PR DESCRIPTION
The property name doesn't have the right case and causes Openshift to default to something else.
In addition, the format of the ranges is wrong.