### PR TITLE
The example of using ft needs updating

### DIFF
--- a/redis_enterprise_database_api.md
+++ b/redis_enterprise_database_api.md
@@ -105,8 +105,8 @@ Redis Enterprise Module: https://redislabs.com/redis-enterprise/modules/
 
 | Field | Description | Scheme | Default Value | Required |
 | ----- | ----------- | ------ | -------- | -------- |
-| name | The module's name e.g \"ft\" for redissearch | string |  | true |
-| version | Module's semantic version e.g \"1.6.12\" | string |  | true |
+| name | The module's name e.g \"search\" for redissearch | string |  | true |
+| version | Module's semantic version e.g \"2.2.6\" | string |  | true |
 | config | Module command line arguments e.g. VKEY_MAX_ENTITY_COUNT 30 | string |  | false |
 [Back to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
The search module is now reported as "search" according to the API and no longer as FT according to the docs:

```
curl INFO:/v1/modules 
{
...
        "min_redis_pack_version": "6.0.8",
        "min_redis_version": "6.0",
        "module_name": "search",
        "semantic_version": "2.2.6",
        "sha256": "7a98c5501d7e86269bb0cb8f752032f64e11ea10a5f640f011ed33921d9cd956",
        "uid": "ee706bdebb5c94658005e25184b0953c",
        "version": 20206
    },
```