### PR TITLE
RED-79996 - return an empty list instead of 'None' if there are no po…

### DIFF
--- a/log_collector/log_collector.py
+++ b/log_collector/log_collector.py
@@ -582,7 +582,7 @@ def get_pod_names(namespace, k8s_cli, selector=""):
     pods = get_pods(namespace, k8s_cli, selector)
     if not pods:
         logger.info("Namespace '%s': Cannot find pods", namespace)
-        return None
+        return []
     return [pod['metadata']['name'] for pod in pods]
 
 


### PR DESCRIPTION
…ds matching a selector

get_pod_names should always return a list, even if it's an empty list, since the callers of the function
expect the return value to always be a list.