### PR TITLE
Add label for docs

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -797,6 +797,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-enterprise-operator
+  labels:
+    name: redis-enterprise-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Documentation has label but deployment.yaml doesnt. 
https://docs.redis.com/latest/kubernetes/deployment/quick-start/#verify-the-operator-is-running